### PR TITLE
Use public link to Docker Hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# docker-fish [![Docker pulls](https://img.shields.io/docker/pulls/andreiborisov/fish.svg?logo=docker&label=pulls&color=2396ed)](https://hub.docker.com/repository/docker/andreiborisov/fish)
+# docker-fish [![Docker pulls](https://img.shields.io/docker/pulls/andreiborisov/fish.svg?logo=docker&label=pulls&color=2396ed)](https://hub.docker.com/r/andreiborisov/fish)
 
 > Dockerfiles for running various versions of the [fish shell](https://fishshell.com)
 


### PR DESCRIPTION
Previous link was private and requested to log in